### PR TITLE
Created MFA compliant auth request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Using the Tesla API with Postman
 
-## Authentcation
-**PLEASE READ STEPS DOCUMENTATION BEFORE ATTEMPTING AUTHENTICATION.**  The authentication sequence follows the sequence outlined [here](https://tesla-api.timdorr.com/api-basics/authentication).  Familarity with [Postman](https://www.postman.com/) is recommended.  Execute steps 1 to 4 to receive an access token that can be used with API calls.  Note that some authentication information is time sensitive so the steps should be completed in a five minute period.
+**PLEASE READ STEPS DOCUMENTATION BEFORE ATTEMPTING AUTHENTICATION.**  The authentication sequence follows the sequence outlined [here](https://tesla-api.timdorr.com/api-basics/authentication).  Familarity with [Postman](https://www.postman.com/) is recommended. You must obtain an access token through one of two methods.
 
-### There is no support for MFA at this time.  Step 3 will fail without MFA support.
+1. Use Authentication (Without MFA) if your account does not have MFA enabled, and to observe each authentication step directly.
+2. Use Authentcation (With or Without MFA) if your account has MFA enabled, or if you do not want to store your account credentials in Postman. This process will use a browser based session on Tesla's website to generate the access token.
+
+Note that some authentication information is time sensitive so the steps should be completed in a five minute period.
+## Authentcation (Without MFA)
+### Step 3 will fail without MFA support. If your account has MFA enabled, skip to 
 
 ### Step 1: Request Log In Page
 
@@ -49,6 +53,37 @@ The Body defines a JSON document for the call.  Update the client ID and secret 
 
 The Tests extract access and refresh tokens.  The access token is stored in the environment variable named teslaBearerToken.  The refresh token is stored in the environment variable named teslaRefreshToken.
 
+## Authentcation (With or Without MFA)
+### Step 1: Setup Environment
+
+USER PREPARATION: Obtain the Client_ID and Client_Secret for the Telsa Owners API which can be found [here](https://www.teslaapi.io/authentication/oauth).
+
+#### Documentation
+
+Open the environment variables in Postman and updated the current value for clientid and clientsecret with the values obtained in the User Preparation section. Save and close environment variables.
+
+Open the Get Access Token with MFA request. Click on the Authorization tab. Update the State variable with a random string of characters.
+
+### Step 2: Obtain Authorization Token from the Tesla SSO server
+
+NOTE: The token will expire after 5 minutes. If you do not perform step 3 in that time frame you will be required to repeat this step.
+
+#### Documentation
+
+In the Get Access Token with MFA request, under the Authorization tab, scroll down to the bottom and click Get New Access Token.
+
+A new browser based window will open to the Tesla SSO website. Enter your Tesla credentials and satisfy MFA if you have it enabled on your account.
+
+The window will automatically close, and Postman will display the authorization token it received. Click on Use Token.
+
+### Step 3: Exchange Authorization Token for Access Token
+#### Documentation
+
+In the Get Access Token with MFA request, click on Send.
+
+The Tests extract access and refresh tokens.  The access token is stored in the environment variable named teslaBearerToken.  The refresh token is stored in the environment variable named teslaRefreshToken.
+
+NOTE: This refresh token cannot be used to refresh your access token. You must repeate Step 2 to obtain a new Authorization token, then repeat this step to obtain a new token.
 
 ## Using the APIs
 

--- a/Tesla API.postman_collection.json
+++ b/Tesla API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cb8af463-690b-4349-9706-2ca779846576",
+		"_postman_id": "ff60a7e2-d97b-4b18-a589-b0af9239765d",
 		"name": "Tesla API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -600,6 +600,116 @@
 					"raw": "{{tokenEndPoint}}token",
 					"host": [
 						"{{tokenEndPoint}}token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Access Token with MFA",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"//extract bearer and refresh tokens\r",
+							"// bearer token: for use in API calls such as Wake Vehicle and Get Vehicle Data; valid for 45 days\r",
+							"// refresh token: this is useless with the current OAuth implementation\r",
+							"\r",
+							"if(responseCode.code == 200)\r",
+							"{\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.environment.set(\"teslaBearerToken\", jsonData.access_token);\r",
+							"    pm.environment.set(\"teslaRefreshToken\", jsonData.refresh_token);\r",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "oauth2",
+					"oauth2": [
+						{
+							"key": "addTokenTo",
+							"value": "header",
+							"type": "string"
+						},
+						{
+							"key": "state",
+							"value": "EnterRandomCharactersHere",
+							"type": "string"
+						},
+						{
+							"key": "clientId",
+							"value": "ownerapi",
+							"type": "string"
+						},
+						{
+							"key": "accessTokenUrl",
+							"value": "https://auth.tesla.com/oauth2/v3/token",
+							"type": "string"
+						},
+						{
+							"key": "authUrl",
+							"value": "https://auth.tesla.com/oauth2/v3/authorize",
+							"type": "string"
+						},
+						{
+							"key": "tokenName",
+							"value": "Tesla Owners API Token",
+							"type": "string"
+						},
+						{
+							"key": "scope",
+							"value": "openid email offline_access",
+							"type": "string"
+						},
+						{
+							"key": "redirect_uri",
+							"value": "https://auth.tesla.com/void/callback",
+							"type": "string"
+						},
+						{
+							"key": "grant_type",
+							"value": "authorization_code_with_pkce",
+							"type": "string"
+						},
+						{
+							"key": "client_authentication",
+							"value": "header",
+							"type": "string"
+						},
+						{
+							"key": "tokenType",
+							"value": "Bearer",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"grant_type\": \"urn:ietf:params:oauth:grant-type:jwt-bearer\",\r\n    \"client_id\": \"{{clientid}}\",\r\n    \"client_secret\": \"{{clientsecret}}\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://owner-api.teslamotors.com/oauth/token",
+					"protocol": "https",
+					"host": [
+						"owner-api",
+						"teslamotors",
+						"com"
+					],
+					"path": [
+						"oauth",
+						"token"
 					]
 				}
 			},

--- a/Tesla Environment.postman_environment.json
+++ b/Tesla Environment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "9bb40a12-5b2e-4726-8981-0bc4e7f109e8",
+	"id": "5fc0857b-cbf3-470d-918b-c155932a2073",
 	"name": "Tesla Environment",
 	"values": [
 		{
@@ -81,9 +81,19 @@
 			"key": "tokenEndPoint",
 			"value": "https://auth.tesla.com/oauth2/v3/",
 			"enabled": true
+		},
+		{
+			"key": "clientid",
+			"value": "ENTER_CLIENT_ID",
+			"enabled": true
+		},
+		{
+			"key": "clientsecret",
+			"value": "ENTER_CLIENT_SECRET",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2021-03-30T00:03:00.978Z",
-	"_postman_exported_using": "Postman/8.0.7"
+	"_postman_exported_at": "2021-04-02T16:43:59.758Z",
+	"_postman_exported_using": "Postman/8.0.10"
 }


### PR DESCRIPTION
I've updated this collection with a new request utilizing Postman's built-in authentication function to handle OAuth to the Tesla API in an MFA compliant way. To use this function perform the following steps.

1. Edit the environment variables to include the ClientID and ClientSecret. I have not included these as I'm not sure what the legal ramifications would be for sharing it. You can find the values on the TeslaAPI documentation pages though.
2. Open the request named "Get Access Token with MFA"
3. Click on Authorization tab, scroll down and hit Get New Access Token
4. You should see a new window open up with the Tesla SSO site, sign in and satisfy MFA
5. Postman will display the token, click on Use Token
6. Within 5 minutes of completing step 4, hit Send on the Get Access Token with MFA request to automatically convert the authorization token into a Owners API access token

In order to refresh the token, currently you must perform steps 2-6 as the refresh token issued by the OwnersAPI cannot be used to refresh the token. Technically there is a refresh token inside of the authorization token you can use, but it is faster and easier to just hit Get New Access Token again.